### PR TITLE
Fix denix host value access after nixpkgs update

### DIFF
--- a/lib/configurations/default.nix
+++ b/lib/configurations/default.nix
@@ -139,6 +139,10 @@
                       inherit currentHostName useHomeManagerModule homeManagerUser;
                     };
                     inherit useHomeManagerModule homeManagerUser; # otherwise it's impossible to make config.home-manager optional when not useHomeManagerModule.
+                  }
+                  // lib.optionalAttrs (currentHostName != null) {
+                    host = nixosSystem.config.${myconfigName}.hosts.${currentHostName};
+                    hosts = nixosSystem.config.${myconfigName}.hosts;
                   };
                   modules =
                     (internalExtraModules "nixos")
@@ -155,6 +159,10 @@
                       inherit currentHostName useHomeManagerModule homeManagerUser;
                     };
                     inherit useHomeManagerModule homeManagerUser; # otherwise it's impossible to make config.home-manager optional when not useHomeManagerModule.
+                  }
+                  // lib.optionalAttrs (currentHostName != null) {
+                    host = homeSystem.config.${myconfigName}.hosts.${currentHostName};
+                    hosts = homeSystem.config.${myconfigName}.hosts;
                   };
                   pkgs = homeManagerNixpkgs.legacyPackages.${homeManagerSystem};
                   modules = (internalExtraModules "home") ++ extraModules ++ files ++ extensionsModules;
@@ -167,6 +175,10 @@
                       inherit currentHostName useHomeManagerModule homeManagerUser;
                     };
                     inherit useHomeManagerModule homeManagerUser; # otherwise it's impossible to make config.home-manager optional when not useHomeManagerModule.
+                  }
+                  // lib.optionalAttrs (currentHostName != null) {
+                    host = darwinSystem.config.${myconfigName}.hosts.${currentHostName};
+                    hosts = darwinSystem.config.${myconfigName}.hosts;
                   };
                   # FIXME: is this really necessary?
                   # pkgs = ...;


### PR DESCRIPTION
Pass `host` and `hosts` via `specialArgs` to restore access in modules after Nixpkgs module system changes.

Nixpkgs commit `c58ada2eda15d0576e9a2ad74bd8f2318509a40f` altered the module system's argument resolution, making it stricter by prioritizing `specialArgs` over `_module.args` for initial function application. This change broke `denix`'s previous method of injecting `host` via `_module.args`, as it was no longer available early enough. This PR adapts `denix` to pass `host` and `hosts` through `specialArgs`, ensuring they are immediately accessible to modules as intended.

---
<a href="https://cursor.com/background-agent?bcId=bc-708d1520-6d72-4bdc-a17e-154c2f31ce24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-708d1520-6d72-4bdc-a17e-154c2f31ce24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

